### PR TITLE
CKAR-8 Dashboard Pages workflow 보강

### DIFF
--- a/.github/workflows/dashboard-pages.yml
+++ b/.github/workflows/dashboard-pages.yml
@@ -1,5 +1,8 @@
 name: Deploy Dashboard to GitHub Pages
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches:
@@ -44,6 +47,8 @@ jobs:
 
       - name: Configure Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Jira Epic
CKAR-8

## 작성 규칙
- [x] PR 제목과 본문은 한국어를 기본으로 작성했습니다.
- [x] 기술명, 명령어, API, 클래스명, 파일명은 영어/원문 표기를 유지했습니다.

## 요약
- `actions/configure-pages@v5`에 `enablement: true`를 추가해 Pages site 설정을 workflow에서 보강했습니다.
- Actions의 Node 20 deprecation warning을 줄이기 위해 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`를 추가했습니다.

## 실패 원인
- 기존 run은 `actions/configure-pages@v5`가 Pages site 정보를 조회하는 단계에서 404를 받았습니다.
- 이는 저장소 Pages가 아직 GitHub Actions 방식으로 완전히 활성화되지 않았거나, 첫 실행 시점에 Pages site 생성이 완료되지 않아 발생할 수 있습니다.
- `enablement: true`를 명시해 workflow가 Pages site 활성화를 함께 시도하도록 보강했습니다.

## 검증
- [x] dashboard: `npm run build`
- [x] workflow 변경만 포함되는지 `git diff --stat origin/main...HEAD`로 확인했습니다.

## Closes
N/A - CKAR-8 Pages workflow 보강 PR입니다.
