### PR TITLE
CKAR-8 simplify dashboard UI: remove hero image, unify to 2 colors

### DIFF
--- a/dashboard/src/pages/OverviewPage.tsx
+++ b/dashboard/src/pages/OverviewPage.tsx
@@ -1,4 +1,3 @@
-import heroImage from '../assets/hero.png';
 import { MetricCard } from '../components/MetricCard';
 import { SectionHeader } from '../components/SectionHeader';
 import type { DashboardData } from '../types';
@@ -21,7 +20,6 @@ export function OverviewPage({ data }: OverviewPageProps) {
           <p>{data.overview.tagline}</p>
           <strong>{data.overview.sourcePrinciple}</strong>
         </div>
-        <img src={heroImage} alt="CKArena dashboard visual" />
       </div>
 
       <div className="metric-grid">

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -1,3 +1,4 @@
+/* ─── Reset ─────────────────────────────────────────── */
 *,
 *::before,
 *::after {
@@ -27,6 +28,7 @@ a {
   text-decoration: none;
 }
 
+/* ─── Layout ─────────────────────────────────────────── */
 .app-shell {
   display: grid;
   grid-template-columns: 280px minmax(0, 1fr);
@@ -42,6 +44,17 @@ a {
   background: #ffffff;
 }
 
+.content {
+  width: min(1180px, 100%);
+  padding: 34px;
+}
+
+.page-stack {
+  display: grid;
+  gap: 24px;
+}
+
+/* ─── Sidebar ────────────────────────────────────────── */
 .brand {
   display: flex;
   align-items: center;
@@ -88,8 +101,8 @@ a {
 }
 
 .nav-item.active {
-  border-color: #c72c41;
-  background: #fff4f4;
+  border-color: #1f6f63;
+  background: #eef5f4;
 }
 
 .nav-item strong,
@@ -110,47 +123,34 @@ a {
   font-size: 0.92rem;
 }
 
-.content {
-  width: min(1180px, 100%);
-  padding: 34px;
-}
-
-.page-stack {
-  display: grid;
-  gap: 24px;
-}
-
+/* ─── Hero band (compact, no image) ─────────────────── */
 .hero-band {
-  display: grid;
-  grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
-  gap: 24px;
-  align-items: stretch;
-  overflow: hidden;
+  padding: 28px 34px;
   border: 1px solid #d9ded8;
   border-radius: 8px;
   background: #ffffff;
+  border-left: 4px solid #1f6f63;
 }
 
 .hero-copy {
   display: grid;
-  align-content: center;
-  gap: 14px;
-  padding: 34px;
+  gap: 10px;
 }
 
 .hero-copy span,
 .section-header span {
-  color: #c72c41;
+  color: #1f6f63;
   font-size: 0.86rem;
   font-weight: 800;
   text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .hero-copy h1,
 .section-header h1 {
   margin: 0;
-  font-size: 2.4rem;
-  line-height: 1.12;
+  font-size: 2rem;
+  line-height: 1.15;
 }
 
 .hero-copy p,
@@ -160,16 +160,12 @@ a {
 }
 
 .hero-copy strong {
-  color: #1f6f63;
+  font-size: 0.9rem;
+  color: #6a7069;
+  font-weight: 400;
 }
 
-.hero-band img {
-  width: 100%;
-  height: 100%;
-  min-height: 260px;
-  object-fit: cover;
-}
-
+/* ─── Metric cards ───────────────────────────────────── */
 .metric-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -178,7 +174,6 @@ a {
 
 .metric-card,
 .content-band,
-.doc-card,
 .timeline-item,
 .decision-item {
   border: 1px solid #d9ded8;
@@ -193,16 +188,18 @@ a {
 .metric-card span {
   display: block;
   color: #6a7069;
+  font-size: 0.88rem;
 }
 
 .metric-card strong {
   display: block;
   margin-top: 8px;
   font-size: 2rem;
+  line-height: 1;
 }
 
 .tone-red {
-  border-top: 4px solid #c72c41;
+  border-top: 4px solid #1f6f63;
 }
 
 .tone-green {
@@ -210,13 +207,14 @@ a {
 }
 
 .tone-cyan {
-  border-top: 4px solid #087b8f;
+  border-top: 4px solid #1c1f23;
 }
 
 .tone-neutral {
   border-top: 4px solid #1c1f23;
 }
 
+/* ─── Section header + content band ─────────────────── */
 .content-band {
   padding: 24px;
 }
@@ -230,30 +228,50 @@ a {
 blockquote {
   margin: 0;
   padding: 18px;
-  border-left: 4px solid #c72c41;
-  background: #fff8f4;
+  border-left: 4px solid #1f6f63;
+  background: #eef5f4;
   color: #2d3230;
 }
 
-.doc-grid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 12px;
+/* ─── Progress bars ──────────────────────────────────── */
+.progress-summary {
+  background: #ffffff;
+  border: 1px solid #d9ded8;
+  border-radius: 8px;
+  padding: 1.25rem 1.5rem;
 }
 
-.doc-card {
-  display: grid;
-  gap: 8px;
-  min-height: 108px;
-  padding: 14px;
+.progress-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.875rem;
+  margin-bottom: 0.4rem;
+  color: #1c1f23;
 }
 
-.doc-card span {
-  color: #6a7069;
-  font-size: 0.88rem;
-  overflow-wrap: anywhere;
+.progress-bar-wrap {
+  height: 8px;
+  background: #d9ded8;
+  border-radius: 4px;
+  overflow: hidden;
 }
 
+.progress-bar-fill {
+  height: 100%;
+  background: #1c1f23;
+  border-radius: 4px;
+  transition: width 0.3s ease;
+}
+
+.progress-bar-fill.progress-bar-green {
+  background: #1f6f63;
+}
+
+.progress-bar-fill.progress-bar-cyan {
+  background: #1c1f23;
+}
+
+/* ─── Timeline / Roadmap ─────────────────────────────── */
 .timeline,
 .decision-list {
   display: grid;
@@ -296,61 +314,45 @@ blockquote {
 }
 
 .status-진행중 {
-  border-color: #c72c41;
-  color: #c72c41;
+  border-color: #1c1f23;
+  color: #1c1f23;
 }
 
-.two-column {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 16px;
-}
-
-.flow-row {
-  display: grid;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
-  gap: 10px;
-}
-
-.flow-step {
-  display: grid;
-  min-height: 72px;
-  place-items: center;
-  padding: 12px;
-  border: 1px solid #d9ded8;
-  border-radius: 8px;
-  background: #ffffff;
-  font-weight: 800;
-  text-align: center;
-}
-
-.check-list li + li {
-  margin-top: 10px;
-}
-
-.check-list.compact {
-  columns: 2;
-}
-
-.pill-list {
+/* ─── Epic progress in Roadmap ───────────────────────── */
+.epic-progress {
   display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin: 0.5rem 0 0.75rem;
 }
 
-.pill-list span {
-  padding: 8px 12px;
-  border: 1px solid #d9ded8;
-  border-radius: 8px;
-  background: #f7f8f5;
+.epic-row {
+  display: grid;
+  grid-template-columns: 72px 1fr 40px;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.8rem;
 }
 
+.epic-key {
+  font-family: monospace;
+  color: #6a7069;
+  font-weight: 600;
+}
+
+.epic-count {
+  text-align: right;
+  color: #6a7069;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ─── Decisions ──────────────────────────────────────── */
 .decision-item {
   padding: 22px;
 }
 
 .decision-item time {
-  color: #c72c41;
+  color: #1f6f63;
   font-weight: 800;
 }
 
@@ -374,6 +376,36 @@ blockquote {
   color: #5d655f;
 }
 
+/* ─── Misc ───────────────────────────────────────────── */
+.two-column {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.pill-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.pill-list span {
+  padding: 8px 12px;
+  border: 1px solid #d9ded8;
+  border-radius: 8px;
+  background: #f7f8f5;
+  font-size: 0.9rem;
+}
+
+.check-list li + li {
+  margin-top: 10px;
+}
+
+.check-list.compact {
+  columns: 2;
+}
+
+/* ─── Responsive ─────────────────────────────────────── */
 @media (max-width: 900px) {
   .app-shell {
     grid-template-columns: 1fr;
@@ -387,110 +419,36 @@ blockquote {
   }
 
   .nav-list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
   .content {
     padding: 20px;
   }
 
-  .hero-band,
   .timeline-item,
   .two-column,
   .decision-item dl {
     grid-template-columns: 1fr;
   }
 
-  .metric-grid,
-  .doc-grid {
+  .metric-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .flow-row {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
 
 @media (max-width: 560px) {
   .nav-list,
-  .metric-grid,
-  .doc-grid,
-  .flow-row {
+  .metric-grid {
     grid-template-columns: 1fr;
   }
 
   .hero-copy h1,
   .section-header h1 {
-    font-size: 1.9rem;
+    font-size: 1.6rem;
   }
 
   .check-list.compact {
     columns: 1;
   }
-}
-
-/* Progress bars */
-.progress-summary {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 1.25rem 1.5rem;
-}
-
-.progress-row {
-  display: flex;
-  justify-content: space-between;
-  font-size: 0.875rem;
-  margin-bottom: 0.4rem;
-  color: var(--text);
-}
-
-.progress-bar-wrap {
-  height: 8px;
-  background: var(--border);
-  border-radius: 4px;
-  overflow: hidden;
-}
-
-.progress-bar-fill {
-  height: 100%;
-  background: var(--text-h);
-  border-radius: 4px;
-  transition: width 0.3s ease;
-}
-
-.progress-bar-fill.progress-bar-green {
-  background: #1f6f63;
-}
-
-.progress-bar-fill.progress-bar-cyan {
-  background: #087b8f;
-}
-
-/* Epic progress in Roadmap */
-.epic-progress {
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-  margin: 0.5rem 0 0.75rem;
-}
-
-.epic-row {
-  display: grid;
-  grid-template-columns: 72px 1fr 40px;
-  align-items: center;
-  gap: 0.6rem;
-  font-size: 0.8rem;
-}
-
-.epic-key {
-  font-family: monospace;
-  color: var(--text);
-  font-weight: 600;
-}
-
-.epic-count {
-  text-align: right;
-  color: var(--text);
-  font-variant-numeric: tabular-nums;
 }


### PR DESCRIPTION
## Jira Epic
CKAR-8

## Summary
- Hero 이미지 제거 → 그린 left border 컴팩트 텍스트 헤더로 교체
- 액센트 색상 2개로 통일: `#1f6f63` (그린) + `#1c1f23` (다크 차콜)
- 빨간(`#c72c41`), 청록(`#087b8f`) 전부 제거

## Test plan
- [ ] Overview hero 이미지 없음 확인
- [ ] 전체 페이지 색상이 그린/다크 2색으로만 구성됨 확인
- [ ] GitHub Actions 배포 후 Pages 정상 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added progress visualization components for tracking roadmap and epic status.

* **Style**
  * Updated dashboard color scheme from red/pink to teal/green across navigation, hero section, and status indicators.
  * Redesigned hero section layout with updated typography sizing and styling.
  * Enhanced metric card and component styling for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->