### PR TITLE
[CKAR-3] Guest 인증 API 구현

### DIFF
--- a/backend/src/main/java/com/ckarena/backend/common/interceptor/AuthInterceptor.java
+++ b/backend/src/main/java/com/ckarena/backend/common/interceptor/AuthInterceptor.java
@@ -1,0 +1,37 @@
+package com.ckarena.backend.common.interceptor;
+
+import com.ckarena.backend.domain.user.entity.GuestSession;
+import com.ckarena.backend.domain.user.repository.GuestSessionRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class AuthInterceptor implements HandlerInterceptor {
+
+    private final GuestSessionRepository guestSessionRepository;
+
+    public AuthInterceptor(GuestSessionRepository guestSessionRepository) {
+        this.guestSessionRepository = guestSessionRepository;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String header = request.getHeader("Authorization");
+        if (header == null || !header.startsWith("Bearer ")) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "인증 토큰이 필요합니다.");
+            return false;
+        }
+
+        String token = header.substring(7);
+        GuestSession session = guestSessionRepository.findBySessionToken(token).orElse(null);
+        if (session == null) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+            return false;
+        }
+
+        request.setAttribute("currentUser", session.getUser());
+        return true;
+    }
+}

--- a/backend/src/main/java/com/ckarena/backend/common/interceptor/WebMvcConfig.java
+++ b/backend/src/main/java/com/ckarena/backend/common/interceptor/WebMvcConfig.java
@@ -1,0 +1,25 @@
+package com.ckarena.backend.common.interceptor;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final AuthInterceptor authInterceptor;
+
+    public WebMvcConfig(AuthInterceptor authInterceptor) {
+        this.authInterceptor = authInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor)
+                .addPathPatterns("/api/**")
+                .excludePathPatterns(
+                        "/api/health",
+                        "/api/auth/**"
+                );
+    }
+}

--- a/backend/src/main/java/com/ckarena/backend/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/ckarena/backend/domain/auth/controller/AuthController.java
@@ -1,0 +1,24 @@
+package com.ckarena.backend.domain.auth.controller;
+
+import com.ckarena.backend.domain.auth.dto.GuestAuthRequest;
+import com.ckarena.backend.domain.auth.dto.GuestAuthResponse;
+import com.ckarena.backend.domain.auth.service.AuthService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/guest")
+    public ResponseEntity<GuestAuthResponse> createGuest(@Valid @RequestBody GuestAuthRequest request) {
+        return ResponseEntity.ok(authService.createGuestSession(request.nickname()));
+    }
+}

--- a/backend/src/main/java/com/ckarena/backend/domain/auth/dto/GuestAuthRequest.java
+++ b/backend/src/main/java/com/ckarena/backend/domain/auth/dto/GuestAuthRequest.java
@@ -1,0 +1,8 @@
+package com.ckarena.backend.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record GuestAuthRequest(
+        @NotBlank @Size(min = 2, max = 30) String nickname
+) {}

--- a/backend/src/main/java/com/ckarena/backend/domain/auth/dto/GuestAuthResponse.java
+++ b/backend/src/main/java/com/ckarena/backend/domain/auth/dto/GuestAuthResponse.java
@@ -1,0 +1,6 @@
+package com.ckarena.backend.domain.auth.dto;
+
+public record GuestAuthResponse(
+        String sessionToken,
+        String nickname
+) {}

--- a/backend/src/main/java/com/ckarena/backend/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/ckarena/backend/domain/auth/service/AuthService.java
@@ -1,0 +1,28 @@
+package com.ckarena.backend.domain.auth.service;
+
+import com.ckarena.backend.domain.auth.dto.GuestAuthResponse;
+import com.ckarena.backend.domain.user.entity.GuestSession;
+import com.ckarena.backend.domain.user.entity.User;
+import com.ckarena.backend.domain.user.repository.GuestSessionRepository;
+import com.ckarena.backend.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final GuestSessionRepository guestSessionRepository;
+
+    public AuthService(UserRepository userRepository, GuestSessionRepository guestSessionRepository) {
+        this.userRepository = userRepository;
+        this.guestSessionRepository = guestSessionRepository;
+    }
+
+    @Transactional
+    public GuestAuthResponse createGuestSession(String nickname) {
+        User user = userRepository.save(new User(nickname));
+        GuestSession session = guestSessionRepository.save(new GuestSession(user));
+        return new GuestAuthResponse(session.getSessionToken(), user.getNickname());
+    }
+}

--- a/backend/src/main/java/com/ckarena/backend/domain/user/entity/GuestSession.java
+++ b/backend/src/main/java/com/ckarena/backend/domain/user/entity/GuestSession.java
@@ -1,0 +1,37 @@
+package com.ckarena.backend.domain.user.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "guest_sessions")
+public class GuestSession {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, unique = true, length = 36)
+    private String sessionToken;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    protected GuestSession() {}
+
+    public GuestSession(User user) {
+        this.user = user;
+        this.sessionToken = UUID.randomUUID().toString();
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public Long getId() { return id; }
+    public User getUser() { return user; }
+    public String getSessionToken() { return sessionToken; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+}

--- a/backend/src/main/java/com/ckarena/backend/domain/user/entity/User.java
+++ b/backend/src/main/java/com/ckarena/backend/domain/user/entity/User.java
@@ -1,0 +1,30 @@
+package com.ckarena.backend.domain.user.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 30)
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private UserRole role = UserRole.GUEST;
+
+    protected User() {}
+
+    public User(String nickname) {
+        this.nickname = nickname;
+        this.role = UserRole.GUEST;
+    }
+
+    public Long getId() { return id; }
+    public String getNickname() { return nickname; }
+    public UserRole getRole() { return role; }
+}

--- a/backend/src/main/java/com/ckarena/backend/domain/user/entity/UserRole.java
+++ b/backend/src/main/java/com/ckarena/backend/domain/user/entity/UserRole.java
@@ -1,0 +1,5 @@
+package com.ckarena.backend.domain.user.entity;
+
+public enum UserRole {
+    GUEST, MEMBER, ADMIN
+}

--- a/backend/src/main/java/com/ckarena/backend/domain/user/repository/GuestSessionRepository.java
+++ b/backend/src/main/java/com/ckarena/backend/domain/user/repository/GuestSessionRepository.java
@@ -1,0 +1,10 @@
+package com.ckarena.backend.domain.user.repository;
+
+import com.ckarena.backend.domain.user.entity.GuestSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface GuestSessionRepository extends JpaRepository<GuestSession, Long> {
+    Optional<GuestSession> findBySessionToken(String sessionToken);
+}

--- a/backend/src/main/java/com/ckarena/backend/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/ckarena/backend/domain/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.ckarena.backend.domain.user.repository;
+
+import com.ckarena.backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/backend/src/test/java/com/ckarena/backend/HealthControllerTest.java
+++ b/backend/src/test/java/com/ckarena/backend/HealthControllerTest.java
@@ -1,8 +1,10 @@
 package com.ckarena.backend;
 
+import com.ckarena.backend.common.interceptor.AuthInterceptor;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -13,6 +15,9 @@ class HealthControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockBean
+    AuthInterceptor authInterceptor;
 
     @Test
     void health_returns_ok() throws Exception {

--- a/backend/src/test/java/com/ckarena/backend/domain/auth/AuthControllerTest.java
+++ b/backend/src/test/java/com/ckarena/backend/domain/auth/AuthControllerTest.java
@@ -1,0 +1,66 @@
+package com.ckarena.backend.domain.auth;
+
+import com.ckarena.backend.common.interceptor.AuthInterceptor;
+import com.ckarena.backend.domain.auth.controller.AuthController;
+import com.ckarena.backend.domain.auth.dto.GuestAuthResponse;
+import com.ckarena.backend.domain.auth.service.AuthService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AuthController.class)
+class AuthControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    AuthService authService;
+
+    // AuthInterceptor 는 이 테스트 범위 밖이므로 Mock 등록
+    @MockBean
+    AuthInterceptor authInterceptor;
+
+    @Test
+    void createGuest_성공() throws Exception {
+        given(authService.createGuestSession("Faker팬123"))
+                .willReturn(new GuestAuthResponse("test-token-uuid", "Faker팬123"));
+
+        mockMvc.perform(post("/api/auth/guest")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("nickname", "Faker팬123"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sessionToken").value("test-token-uuid"))
+                .andExpect(jsonPath("$.nickname").value("Faker팬123"));
+    }
+
+    @Test
+    void createGuest_닉네임_빈값_400() throws Exception {
+        mockMvc.perform(post("/api/auth/guest")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("nickname", ""))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createGuest_닉네임_1자_400() throws Exception {
+        mockMvc.perform(post("/api/auth/guest")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("nickname", "A"))))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/docs/architecture/API_DESIGN.md
+++ b/docs/architecture/API_DESIGN.md
@@ -21,7 +21,7 @@ Response: { "sessionToken": "...", "nickname": "Faker팬123" }
 ## 초안 Endpoints
 
 ## Auth
-- `POST /api/auth/guest` [예정]: 닉네임으로 임시 세션 토큰 발급.
+- `POST /api/auth/guest` [구현됨]: 닉네임으로 임시 세션 토큰 발급.
 - `POST /api/auth/register` [예정]: 회원가입 (MVP 4).
 - `POST /api/auth/login` [예정]: 로그인 (MVP 4).
 


### PR DESCRIPTION
## Summary
- `User` / `GuestSession` 엔티티 + Repository 추가
- `POST /api/auth/guest` — 닉네임으로 UUID 세션 토큰 발급
- `AuthInterceptor` (HandlerInterceptor) — Bearer 토큰 검증, `request.setAttribute("currentUser", user)`
- `WebMvcConfig` — `/api/**` 보호, `/api/health` · `/api/auth/**` 제외

## Test plan
- [x] `AuthControllerTest`: 성공(200), 빈 닉네임(400), 1자 닉네임(400) — `@WebMvcTest`, DB 불필요
- [x] `HealthControllerTest`: AuthInterceptor MockBean 추가로 기존 테스트 유지
- [ ] Docker MySQL 기동 후 `POST /api/auth/guest` curl 수동 확인

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guest authentication endpoint allowing users to create temporary sessions with a nickname.
  * Implemented Bearer token-based authentication for API requests.
  * Session tokens are now required and validated for protected endpoints.

* **Documentation**
  * Updated API design documentation to reflect newly implemented guest authentication functionality.

* **Tests**
  * Added test coverage for guest authentication endpoint validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->