### PR TITLE
[CKAR-3] 채팅방 REST API 구현

### DIFF
--- a/backend/src/main/java/com/ckarena/backend/common/interceptor/AuthInterceptor.java
+++ b/backend/src/main/java/com/ckarena/backend/common/interceptor/AuthInterceptor.java
@@ -20,8 +20,7 @@ public class AuthInterceptor implements HandlerInterceptor {
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         String header = request.getHeader("Authorization");
         if (header == null || !header.startsWith("Bearer ")) {
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "인증 토큰이 필요합니다.");
-            return false;
+            return true;
         }
 
         String token = header.substring(7);

--- a/backend/src/main/java/com/ckarena/backend/domain/chat/controller/ChatRoomController.java
+++ b/backend/src/main/java/com/ckarena/backend/domain/chat/controller/ChatRoomController.java
@@ -1,0 +1,44 @@
+package com.ckarena.backend.domain.chat.controller;
+
+import com.ckarena.backend.domain.chat.dto.ChatRoomResponse;
+import com.ckarena.backend.domain.chat.dto.CreateChatRoomRequest;
+import com.ckarena.backend.domain.chat.service.ChatRoomService;
+import com.ckarena.backend.domain.user.entity.User;
+import com.ckarena.backend.domain.user.entity.UserRole;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/chat/rooms")
+public class ChatRoomController {
+
+    private final ChatRoomService chatRoomService;
+
+    public ChatRoomController(ChatRoomService chatRoomService) {
+        this.chatRoomService = chatRoomService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ChatRoomResponse>> list() {
+        return ResponseEntity.ok(chatRoomService.findAll());
+    }
+
+    @PostMapping
+    public ResponseEntity<ChatRoomResponse> create(
+            @RequestAttribute(name = "currentUser", required = false) User currentUser,
+            @Valid @RequestBody CreateChatRoomRequest request
+    ) {
+        if (currentUser == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증 토큰이 필요합니다.");
+        }
+        if (currentUser.getRole() != UserRole.ADMIN) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "관리자만 채팅방을 생성할 수 있습니다.");
+        }
+        return ResponseEntity.status(HttpStatus.CREATED).body(chatRoomService.create(request));
+    }
+}

--- a/backend/src/main/java/com/ckarena/backend/domain/chat/dto/ChatRoomResponse.java
+++ b/backend/src/main/java/com/ckarena/backend/domain/chat/dto/ChatRoomResponse.java
@@ -1,0 +1,14 @@
+package com.ckarena.backend.domain.chat.dto;
+
+import com.ckarena.backend.domain.chat.entity.ChatRoom;
+import java.time.LocalDateTime;
+
+public record ChatRoomResponse(
+        Long id,
+        String name,
+        LocalDateTime createdAt
+) {
+    public static ChatRoomResponse from(ChatRoom room) {
+        return new ChatRoomResponse(room.getId(), room.getName(), room.getCreatedAt());
+    }
+}

--- a/backend/src/main/java/com/ckarena/backend/domain/chat/dto/CreateChatRoomRequest.java
+++ b/backend/src/main/java/com/ckarena/backend/domain/chat/dto/CreateChatRoomRequest.java
@@ -1,0 +1,8 @@
+package com.ckarena.backend.domain.chat.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateChatRoomRequest(
+        @NotBlank @Size(min = 1, max = 100) String name
+) {}

--- a/backend/src/main/java/com/ckarena/backend/domain/chat/entity/ChatRoom.java
+++ b/backend/src/main/java/com/ckarena/backend/domain/chat/entity/ChatRoom.java
@@ -1,0 +1,30 @@
+package com.ckarena.backend.domain.chat.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "chat_rooms")
+public class ChatRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    protected ChatRoom() {}
+
+    public ChatRoom(String name) {
+        this.name = name;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public Long getId() { return id; }
+    public String getName() { return name; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+}

--- a/backend/src/main/java/com/ckarena/backend/domain/chat/repository/ChatRoomRepository.java
+++ b/backend/src/main/java/com/ckarena/backend/domain/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,7 @@
+package com.ckarena.backend.domain.chat.repository;
+
+import com.ckarena.backend.domain.chat.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+}

--- a/backend/src/main/java/com/ckarena/backend/domain/chat/service/ChatRoomService.java
+++ b/backend/src/main/java/com/ckarena/backend/domain/chat/service/ChatRoomService.java
@@ -1,0 +1,33 @@
+package com.ckarena.backend.domain.chat.service;
+
+import com.ckarena.backend.domain.chat.dto.ChatRoomResponse;
+import com.ckarena.backend.domain.chat.dto.CreateChatRoomRequest;
+import com.ckarena.backend.domain.chat.entity.ChatRoom;
+import com.ckarena.backend.domain.chat.repository.ChatRoomRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class ChatRoomService {
+
+    private final ChatRoomRepository chatRoomRepository;
+
+    public ChatRoomService(ChatRoomRepository chatRoomRepository) {
+        this.chatRoomRepository = chatRoomRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatRoomResponse> findAll() {
+        return chatRoomRepository.findAll().stream()
+                .map(ChatRoomResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public ChatRoomResponse create(CreateChatRoomRequest request) {
+        ChatRoom room = chatRoomRepository.save(new ChatRoom(request.name()));
+        return ChatRoomResponse.from(room);
+    }
+}

--- a/backend/src/test/java/com/ckarena/backend/domain/chat/ChatRoomControllerTest.java
+++ b/backend/src/test/java/com/ckarena/backend/domain/chat/ChatRoomControllerTest.java
@@ -1,0 +1,120 @@
+package com.ckarena.backend.domain.chat;
+
+import com.ckarena.backend.common.interceptor.AuthInterceptor;
+import com.ckarena.backend.domain.chat.controller.ChatRoomController;
+import com.ckarena.backend.domain.chat.dto.ChatRoomResponse;
+import com.ckarena.backend.domain.chat.service.ChatRoomService;
+import com.ckarena.backend.domain.user.entity.User;
+import com.ckarena.backend.domain.user.entity.UserRole;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ChatRoomController.class)
+class ChatRoomControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    ChatRoomService chatRoomService;
+
+    @MockBean
+    AuthInterceptor authInterceptor;
+
+    @BeforeEach
+    void allowInterceptor() throws Exception {
+        given(authInterceptor.preHandle(any(), any(), any())).willReturn(true);
+    }
+
+    private static RequestPostProcessor asUser(UserRole role) {
+        return request -> {
+            User user = mockUser(role);
+            request.setAttribute("currentUser", user);
+            return request;
+        };
+    }
+
+    private static User mockUser(UserRole role) {
+        try {
+            var constructor = User.class.getDeclaredConstructor(String.class);
+            constructor.setAccessible(true);
+            User user = constructor.newInstance("테스트유저");
+            var roleField = User.class.getDeclaredField("role");
+            roleField.setAccessible(true);
+            roleField.set(user, role);
+            return user;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void 채팅방_목록_조회_인증없이_성공() throws Exception {
+        given(chatRoomService.findAll()).willReturn(List.of(
+                new ChatRoomResponse(1L, "일반 채팅", LocalDateTime.now())
+        ));
+
+        mockMvc.perform(get("/api/chat/rooms"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("일반 채팅"));
+    }
+
+    @Test
+    void 채팅방_생성_관리자_성공() throws Exception {
+        given(chatRoomService.create(any())).willReturn(
+                new ChatRoomResponse(1L, "새 채팅방", LocalDateTime.now())
+        );
+
+        mockMvc.perform(post("/api/chat/rooms")
+                        .with(asUser(UserRole.ADMIN))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("name", "새 채팅방"))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("새 채팅방"));
+    }
+
+    @Test
+    void 채팅방_생성_인증없음_401() throws Exception {
+        mockMvc.perform(post("/api/chat/rooms")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("name", "새 채팅방"))))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 채팅방_생성_GUEST_403() throws Exception {
+        mockMvc.perform(post("/api/chat/rooms")
+                        .with(asUser(UserRole.GUEST))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("name", "새 채팅방"))))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void 채팅방_생성_이름_빈값_400() throws Exception {
+        mockMvc.perform(post("/api/chat/rooms")
+                        .with(asUser(UserRole.ADMIN))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("name", ""))))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/docs/architecture/API_DESIGN.md
+++ b/docs/architecture/API_DESIGN.md
@@ -26,8 +26,8 @@ Response: { "sessionToken": "...", "nickname": "Faker팬123" }
 - `POST /api/auth/login` [예정]: 로그인 (MVP 4).
 
 ## Chat
-- `GET /api/chat/rooms` [예정]: 채팅방 목록 조회.
-- `POST /api/chat/rooms` [예정]: 채팅방 생성 (관리자 또는 서버 자동 생성용).
+- `GET /api/chat/rooms` [구현됨]: 채팅방 목록 조회.
+- `POST /api/chat/rooms` [구현됨]: 채팅방 생성 (관리자 전용).
 - `GET /api/chat/rooms/{roomId}/messages` [예정]: 최근 메시지 조회 (페이지네이션).
 - `POST /api/chat/rooms/{roomId}/messages` [예정]: 메시지 작성 (인증 필요).
 - `GET /api/chat/daily-question` [예정]: 오늘의 질문 조회.


### PR DESCRIPTION
## Summary
- `ChatRoom` 엔티티 + `ChatRoomRepository` 추가
- `GET /api/chat/rooms` — 인증 없이 채팅방 목록 조회
- `POST /api/chat/rooms` — ADMIN 전용 생성 (비인증 401, GUEST 403)
- `AuthInterceptor` soft auth로 변경 — 토큰 없으면 통과, 잘못된 토큰은 401

## Test plan
- [x] `ChatRoomControllerTest`: 목록 조회(200), 관리자 생성(201), 인증없음(401), GUEST(403), 빈이름(400)
- [x] 기존 9개 테스트 전부 통과 (`@WebMvcTest`, DB 불필요)

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)