### PR TITLE
[CKAR-3] 채팅 메시지 REST API 구현

### DIFF
--- a/backend/src/main/java/com/ckarena/backend/domain/chat/controller/ChatMessageController.java
+++ b/backend/src/main/java/com/ckarena/backend/domain/chat/controller/ChatMessageController.java
@@ -1,0 +1,44 @@
+package com.ckarena.backend.domain.chat.controller;
+
+import com.ckarena.backend.domain.chat.dto.ChatMessageResponse;
+import com.ckarena.backend.domain.chat.dto.PageResponse;
+import com.ckarena.backend.domain.chat.dto.SendMessageRequest;
+import com.ckarena.backend.domain.chat.service.ChatMessageService;
+import com.ckarena.backend.domain.user.entity.User;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/api/chat/rooms/{roomId}/messages")
+public class ChatMessageController {
+
+    private final ChatMessageService chatMessageService;
+
+    public ChatMessageController(ChatMessageService chatMessageService) {
+        this.chatMessageService = chatMessageService;
+    }
+
+    @GetMapping
+    public ResponseEntity<PageResponse<ChatMessageResponse>> list(
+            @PathVariable Long roomId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return ResponseEntity.ok(chatMessageService.findMessages(roomId, page, size));
+    }
+
+    @PostMapping
+    public ResponseEntity<ChatMessageResponse> send(
+            @PathVariable Long roomId,
+            @RequestAttribute(name = "currentUser", required = false) User currentUser,
+            @Valid @RequestBody SendMessageRequest request
+    ) {
+        if (currentUser == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증 토큰이 필요합니다.");
+        }
+        return ResponseEntity.status(HttpStatus.CREATED).body(chatMessageService.send(roomId, currentUser, request));
+    }
+}

--- a/backend/src/main/java/com/ckarena/backend/domain/chat/dto/ChatMessageResponse.java
+++ b/backend/src/main/java/com/ckarena/backend/domain/chat/dto/ChatMessageResponse.java
@@ -1,0 +1,20 @@
+package com.ckarena.backend.domain.chat.dto;
+
+import com.ckarena.backend.domain.chat.entity.ChatMessage;
+import java.time.LocalDateTime;
+
+public record ChatMessageResponse(
+        Long id,
+        String nickname,
+        String content,
+        LocalDateTime createdAt
+) {
+    public static ChatMessageResponse from(ChatMessage message) {
+        return new ChatMessageResponse(
+                message.getId(),
+                message.getSender().getNickname(),
+                message.getContent(),
+                message.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/ckarena/backend/domain/chat/dto/PageResponse.java
+++ b/backend/src/main/java/com/ckarena/backend/domain/chat/dto/PageResponse.java
@@ -1,0 +1,24 @@
+package com.ckarena.backend.domain.chat.dto;
+
+import org.springframework.data.domain.Page;
+import java.util.List;
+
+public record PageResponse<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean last
+) {
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return new PageResponse<>(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.isLast()
+        );
+    }
+}

--- a/backend/src/main/java/com/ckarena/backend/domain/chat/dto/SendMessageRequest.java
+++ b/backend/src/main/java/com/ckarena/backend/domain/chat/dto/SendMessageRequest.java
@@ -1,0 +1,8 @@
+package com.ckarena.backend.domain.chat.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SendMessageRequest(
+        @NotBlank @Size(min = 1, max = 500) String content
+) {}

--- a/backend/src/main/java/com/ckarena/backend/domain/chat/entity/ChatMessage.java
+++ b/backend/src/main/java/com/ckarena/backend/domain/chat/entity/ChatMessage.java
@@ -1,0 +1,43 @@
+package com.ckarena.backend.domain.chat.entity;
+
+import com.ckarena.backend.domain.user.entity.User;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "chat_messages")
+public class ChatMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "room_id", nullable = false)
+    private ChatRoom room;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User sender;
+
+    @Column(nullable = false, length = 500)
+    private String content;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    protected ChatMessage() {}
+
+    public ChatMessage(ChatRoom room, User sender, String content) {
+        this.room = room;
+        this.sender = sender;
+        this.content = content;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public Long getId() { return id; }
+    public ChatRoom getRoom() { return room; }
+    public User getSender() { return sender; }
+    public String getContent() { return content; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+}

--- a/backend/src/main/java/com/ckarena/backend/domain/chat/repository/ChatMessageRepository.java
+++ b/backend/src/main/java/com/ckarena/backend/domain/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,10 @@
+package com.ckarena.backend.domain.chat.repository;
+
+import com.ckarena.backend.domain.chat.entity.ChatMessage;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+    Page<ChatMessage> findByRoomIdOrderByCreatedAtDesc(Long roomId, Pageable pageable);
+}

--- a/backend/src/main/java/com/ckarena/backend/domain/chat/service/ChatMessageService.java
+++ b/backend/src/main/java/com/ckarena/backend/domain/chat/service/ChatMessageService.java
@@ -1,0 +1,48 @@
+package com.ckarena.backend.domain.chat.service;
+
+import com.ckarena.backend.domain.chat.dto.ChatMessageResponse;
+import com.ckarena.backend.domain.chat.dto.PageResponse;
+import com.ckarena.backend.domain.chat.dto.SendMessageRequest;
+import com.ckarena.backend.domain.chat.entity.ChatMessage;
+import com.ckarena.backend.domain.chat.entity.ChatRoom;
+import com.ckarena.backend.domain.chat.repository.ChatMessageRepository;
+import com.ckarena.backend.domain.chat.repository.ChatRoomRepository;
+import com.ckarena.backend.domain.user.entity.User;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class ChatMessageService {
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomRepository chatRoomRepository;
+
+    public ChatMessageService(ChatMessageRepository chatMessageRepository, ChatRoomRepository chatRoomRepository) {
+        this.chatMessageRepository = chatMessageRepository;
+        this.chatRoomRepository = chatRoomRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<ChatMessageResponse> findMessages(Long roomId, int page, int size) {
+        findRoomOrThrow(roomId);
+        return PageResponse.from(
+                chatMessageRepository.findByRoomIdOrderByCreatedAtDesc(roomId, PageRequest.of(page, size))
+                        .map(ChatMessageResponse::from)
+        );
+    }
+
+    @Transactional
+    public ChatMessageResponse send(Long roomId, User sender, SendMessageRequest request) {
+        ChatRoom room = findRoomOrThrow(roomId);
+        ChatMessage message = chatMessageRepository.save(new ChatMessage(room, sender, request.content()));
+        return ChatMessageResponse.from(message);
+    }
+
+    private ChatRoom findRoomOrThrow(Long roomId) {
+        return chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다."));
+    }
+}

--- a/backend/src/test/java/com/ckarena/backend/domain/chat/ChatMessageControllerTest.java
+++ b/backend/src/test/java/com/ckarena/backend/domain/chat/ChatMessageControllerTest.java
@@ -1,0 +1,116 @@
+package com.ckarena.backend.domain.chat;
+
+import com.ckarena.backend.common.interceptor.AuthInterceptor;
+import com.ckarena.backend.domain.chat.controller.ChatMessageController;
+import com.ckarena.backend.domain.chat.dto.ChatMessageResponse;
+import com.ckarena.backend.domain.chat.dto.PageResponse;
+import com.ckarena.backend.domain.chat.service.ChatMessageService;
+import com.ckarena.backend.domain.user.entity.User;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ChatMessageController.class)
+class ChatMessageControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    ChatMessageService chatMessageService;
+
+    @MockBean
+    AuthInterceptor authInterceptor;
+
+    @BeforeEach
+    void allowInterceptor() throws Exception {
+        given(authInterceptor.preHandle(any(), any(), any())).willReturn(true);
+    }
+
+    private static RequestPostProcessor asGuest() {
+        return request -> {
+            try {
+                var constructor = User.class.getDeclaredConstructor(String.class);
+                constructor.setAccessible(true);
+                request.setAttribute("currentUser", constructor.newInstance("테스트유저"));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            return request;
+        };
+    }
+
+    @Test
+    void 메시지_목록_조회_인증없이_성공() throws Exception {
+        PageResponse<ChatMessageResponse> page = new PageResponse<>(
+                List.of(new ChatMessageResponse(1L, "Faker팬", "안녕하세요", LocalDateTime.now())),
+                0, 20, 1L, 1, true
+        );
+        given(chatMessageService.findMessages(eq(1L), eq(0), eq(20))).willReturn(page);
+
+        mockMvc.perform(get("/api/chat/rooms/1/messages"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].nickname").value("Faker팬"))
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.last").value(true));
+    }
+
+    @Test
+    void 메시지_전송_인증_성공() throws Exception {
+        given(chatMessageService.send(eq(1L), any(), any()))
+                .willReturn(new ChatMessageResponse(1L, "테스트유저", "안녕!", LocalDateTime.now()));
+
+        mockMvc.perform(post("/api/chat/rooms/1/messages")
+                        .with(asGuest())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("content", "안녕!"))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.content").value("안녕!"));
+    }
+
+    @Test
+    void 메시지_전송_인증없음_401() throws Exception {
+        mockMvc.perform(post("/api/chat/rooms/1/messages")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("content", "안녕!"))))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 메시지_전송_내용_빈값_400() throws Exception {
+        mockMvc.perform(post("/api/chat/rooms/1/messages")
+                        .with(asGuest())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("content", ""))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 메시지_목록_page_size_파라미터() throws Exception {
+        PageResponse<ChatMessageResponse> page = new PageResponse<>(List.of(), 1, 10, 0L, 0, true);
+        given(chatMessageService.findMessages(eq(1L), eq(1), eq(10))).willReturn(page);
+
+        mockMvc.perform(get("/api/chat/rooms/1/messages?page=1&size=10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page").value(1))
+                .andExpect(jsonPath("$.size").value(10));
+    }
+}

--- a/docs/architecture/API_DESIGN.md
+++ b/docs/architecture/API_DESIGN.md
@@ -28,8 +28,8 @@ Response: { "sessionToken": "...", "nickname": "Faker팬123" }
 ## Chat
 - `GET /api/chat/rooms` [구현됨]: 채팅방 목록 조회.
 - `POST /api/chat/rooms` [구현됨]: 채팅방 생성 (관리자 전용).
-- `GET /api/chat/rooms/{roomId}/messages` [예정]: 최근 메시지 조회 (페이지네이션).
-- `POST /api/chat/rooms/{roomId}/messages` [예정]: 메시지 작성 (인증 필요).
+- `GET /api/chat/rooms/{roomId}/messages` [구현됨]: 최근 메시지 조회 (page/size 페이지네이션).
+- `POST /api/chat/rooms/{roomId}/messages` [구현됨]: 메시지 작성 (인증 필요).
 - `GET /api/chat/daily-question` [예정]: 오늘의 질문 조회.
 - **WebSocket** `ws://host/ws`: STOMP 연결 endpoint.
 - **STOMP subscribe** `/topic/chat/{roomId}`: 실시간 채팅 메시지 구독.


### PR DESCRIPTION
## Summary
- `ChatMessage` 엔티티 + `ChatMessageRepository` 추가 (roomId + createdAtDesc 페이징)
- `GET /api/chat/rooms/{roomId}/messages` — 인증 없이 최신순 페이지네이션 조회
- `POST /api/chat/rooms/{roomId}/messages` — 인증 필요 (비인증 401)
- `PageResponse<T>` 공통 페이지네이션 응답 DTO (content/page/size/totalElements/totalPages/last)

## Test plan
- [x] `ChatMessageControllerTest`: 목록 조회(200), 메시지 전송(201), 인증없음(401), 빈내용(400), page/size 파라미터
- [x] 전체 14개 테스트 통과 (`@WebMvcTest`, DB 불필요)

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added chat messaging endpoints to retrieve and send messages in rooms
  * Implemented pagination for browsing message history
  * Added authentication requirement for sending messages
  * Message content validated to be between 1-500 characters

* **Tests**
  * Added comprehensive test coverage for chat messaging functionality

* **Documentation**
  * Updated API documentation to reflect chat messaging endpoints as implemented

<!-- end of auto-generated comment: release notes by coderabbit.ai -->